### PR TITLE
Fix Footer Social Icon Color Not Showing and Refactor Icon Usage

### DIFF
--- a/src/components/Section/Footer/footer.tsx
+++ b/src/components/Section/Footer/footer.tsx
@@ -135,7 +135,7 @@ export default function Footer() {
               >
                 <Twitter
                   className="w-5 h-5"
-                  style={{ color: "var(--color-footer-icon)" }}
+                  style={{ color: "var(--color-foreground)" }}
                 />
               </a>
               <a
@@ -145,7 +145,7 @@ export default function Footer() {
               >
                 <Github
                   className="w-5 h-5"
-                  style={{ color: "var(--color-footer-icon)" }}
+                  style={{ color: "var(--color-foreground)" }}
                 />
               </a>
               <a
@@ -155,7 +155,7 @@ export default function Footer() {
               >
                 <MessageCircle
                   className="w-5 h-5"
-                  style={{ color: "var(--color-footer-icon)" }}
+                  style={{ color: "var(--color-foreground)" }}
                 />
               </a>
             </div>


### PR DESCRIPTION

<img width="1345" height="630" alt="image" src="https://github.com/user-attachments/assets/bd093f41-75d2-48c7-9673-3ee06cfab3eb" />


**PR Description:**  
This pull request resolves an issue where the social icons in the `Footer` component were not displaying the intended color. The color for the Twitter, GitHub, and Discord icons has been updated from the custom CSS variable `var(--color-footer-icon)` to the more general `var(--color-foreground)`, ensuring the icons are visible and consistent with the application's theme.

**Key changes:**  
- Fixed icon color visibility by switching to `var(--color-foreground)`.
- Refactored the `style` prop for all social icons in the footer for improved consistency.

This update ensures the footer icons are properly styled and visible, enhancing UI consistency.