### PR TITLE
refactor: enhance layout and button styling in Hero component for improved responsiveness

### DIFF
--- a/src/components/Section/Hero/Hero.tsx
+++ b/src/components/Section/Hero/Hero.tsx
@@ -3,7 +3,7 @@ import { HiOutlineBolt, HiOutlineStar } from "react-icons/hi2";
 export default function Hero() {
   return (
     <section
-      className="flex flex-col items-center justify-center min-h-screen"
+      className="flex flex-col items-center justify-center min-h-screen mx-auto max-w-2xl px-4"
       style={{ background: "var(--background)" }}
     >
       <div
@@ -43,19 +43,19 @@ export default function Hero() {
         community.
       </p>
 
-      <div className="flex w-full max-w-md gap-4 justify-center mb-12">
-        <button className="font-semibold px-8 py-3 rounded-lg shadow transition bg-gradient-to-r from-[var(--color-hero-gradient-from)] to-[var(--color-hero-gradient-to)] text-background hover:opacity-90">
-          Start Learning →
+      <div className="flex flex-col sm:flex-row mx-auto max-w-md gap-3 sm:gap-6 justify-center mb-12 px-2 w-full">
+        <button className="font-semibold w-full sm:w-auto px-6 sm:px-10 py-2 sm:py-4 rounded-xl shadow-lg transition-transform duration-200 bg-gradient-to-r from-[var(--color-hero-gradient-from)] to-[var(--color-hero-gradient-to)] text-background hover:scale-105 hover:shadow-xl hover:opacity-90 text-base sm:text-xl flex justify-center text-center">
+          <span className="whitespace-nowrap">Start Learning →</span>
         </button>
-        <button className="border shadow font-semibold px-8 py-3 rounded-lg transition flex items-center gap-2 bg-[var(--color-hero-button-bg)] text-[var(--primary-foreground)] border-[var(--border)] hover:bg-opacity-90">
+        <button className="border shadow-lg font-semibold w-full sm:w-auto px-6 sm:px-10 py-2 sm:py-4 rounded-xl transition-transform duration-200 flex items-center justify-center gap-2 bg-[var(--color-hero-button-bg)] text-[var(--primary-foreground)] border-[var(--border)] hover:scale-105 hover:shadow-xl hover:bg-opacity-90 text-base sm:text-xl text-center">
           <span>
             <HiOutlineBolt />
-          </span>{" "}
-          Explore Quizzes
+          </span>
+          <span className="whitespace-nowrap">Explore Quizzes</span>
         </button>
       </div>
 
-      <div className="flex gap-28 mb-8">
+      <div className="flex gap-20 md:gap-28 mb-8 ">
         <div className="text-center">
           <span
             className="block text-2xl font-bold"

--- a/src/components/Section/Hero/Hero.tsx
+++ b/src/components/Section/Hero/Hero.tsx
@@ -7,7 +7,7 @@ export default function Hero() {
       style={{ background: "var(--background)" }}
     >
       <div
-        className="flex items-center gap-1 space-between mb-6 mt-4 px-4 py-1 rounded-full text-xs border font-semibold shadow"
+        className="flex items-center gap-1 justify-center mb-6 mt-4 px-4 py-1 rounded-full text-xs border font-semibold shadow"
         style={{
           background: "var(--card)",
           color: "var(--primary)",
@@ -24,7 +24,7 @@ export default function Hero() {
         className="text-7xl md:text-7xl font-extrabold text-center mb-2"
         style={{ color: "var(--primary-foreground)" }}
       >
-        Learn Defi,
+        Learn DeFi,
       </h1>
 
       <h2


### PR DESCRIPTION


### PR Description 
Summary
-------
Fix mobile layout and visual polish for the Hero section so primary CTA buttons no longer sit flush to the screen edges, are easier to tap on mobile, and look better on larger screens.

Files changed
-------------
- src/components/Section/Hero/Hero.tsx

What  changed
--------------
- Restored/ensured the hero container uses an industry-standard centered column (`mx-auto` + `max-w-*` + `px-*`) so content keeps horizontal gutters on mobile.
- Made CTA buttons responsive:
  - Full-width stacked on mobile (`w-full`, `flex-col` on mobile -> `sm:flex-row` on larger screens).
  - Reduced mobile text size and padding for improved proportion.
  - Kept larger padding and font-size on >=sm for better desktop appearance.
  - Added `whitespace-nowrap` to keep labels on a single line.
  - Centered icons and text inside buttons on mobile (`flex justify-center text-center`).
  - Added subtle hover/scale and shadow effects for desktop polish.
-  adjustments to stat block layout so margins remain consistent with the hero content.

Why
---
- Fixes an accessibility/usability issue where buttons appeared too close to left/right screen edges on phones.
- Improves tap targets and visual hierarchy on mobile while preserving an attractive desktop layout.



<img width="422" height="788" alt="image" src="https://github.com/user-attachments/assets/07356daf-3847-46da-b8f5-724e9ede3800" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Wider, centered Hero container with consistent horizontal padding.
  - Reworked CTAs to be responsive: stacked full-width on small screens, horizontal auto-width on larger screens.
  - Enhanced buttons: larger padding, rounded corners, shadows, and smooth hover/scale effects.
  - Adjusted spacing to better scale across breakpoints; CTA header now centered.

- **Bug Fixes**
  - Corrected Hero title text from "Learn Defi," to "Learn DeFi,".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->