### PR TITLE
feat: add Quiz and QuizCard components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import Hero from "@/components/Section/Hero/Hero";
 import Feature from "../components/Section/Feature/Feature";
 import CTA from "../components/Section/CTA/CTA";
 import About from "@/components/Section/About/About";
+import Quiz from "@/components/Section/Quiz/Quiz";
 
 export default function Home() {
   return (
@@ -10,6 +11,7 @@ export default function Home() {
       <Feature />
       <CTA />
       <About />
+      <Quiz />
     </main>
   );
 }

--- a/src/components/Section/Quiz/Quiz.tsx
+++ b/src/components/Section/Quiz/Quiz.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Brain, Wallet, Network, Image as ImageIcon } from "lucide-react";
+import QuizCard from "./QuizCard";
+
+export default function Quiz() {
+  return (
+    <section className="w-full bg-[var(--background)]">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-16 md:py-24">
+        {/* Section header */}
+        <div className="flex w-full justify-center mb-6">
+          <span className="flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold shadow-sm bg-[var(--card)] text-[var(--primary-foreground)] border-[var(--border)]">
+            <Brain className="h-4 w-4 text-[var(--primary)]" aria-hidden />
+            Web3 Quizzes
+          </span>
+        </div>
+
+        <h2 className="aboutHeadingGradient text-center text-[40px] leading-tight md:text-5xl font-extrabold mb-4">
+          Learn Web3 by Quiz
+        </h2>
+        <p className="text-center text-sm md:text-base mb-10 max-w-2xl mx-auto text-[var(--color-about-description)]">
+          Explore bite-sized quizzes across DeFi, NFTs, L2s, and wallet
+          security. Practice interactively and grow your onchain confidence.
+        </p>
+
+        {/* Top row: categories */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10">
+          <QuizCard
+            icon={
+              <Wallet className="h-5 w-5 text-[var(--primary)]" aria-hidden />
+            }
+            title="DeFi Basics"
+            subtitle="Lending, AMMs, governance"
+          />
+          <QuizCard
+            icon={
+              <ImageIcon
+                className="h-5 w-5 text-[var(--primary)]"
+                aria-hidden
+              />
+            }
+            title="NFTs & Culture"
+            subtitle="Ownership, royalties, metadata"
+          />
+          <QuizCard
+            icon={
+              <Network className="h-5 w-5 text-[var(--primary)]" aria-hidden />
+            }
+            title="Layer 2s"
+            subtitle="Rollups, bridges, gas"
+          />
+        </div>
+
+        {/* CTA */}
+        <div className="mt-10 flex flex-col items-center gap-4">
+          <Button className="px-8 py-6 text-base bg-gradient-to-r from-[var(--color-hero-gradient-from)] to-[var(--color-hero-gradient-to)] text-[var(--background)] hover:opacity-90">
+            Start Web3 Quizzes
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            Earn tokens and badges as you learn.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Section/Quiz/QuizCard.tsx
+++ b/src/components/Section/Quiz/QuizCard.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+
+export default function QuizCard({
+  icon,
+  title,
+  subtitle,
+}: {
+  icon: ReactNode;
+  title: string;
+  subtitle: string;
+}) {
+  return (
+    <Card className="shadow-sm border hover:shadow-md transition-all">
+      <CardHeader className="px-5">
+        <div className="flex items-center gap-3">
+          <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-[var(--card)] border border-[var(--border)]">
+            {icon}
+          </span>
+          <div className="leading-tight">
+            <CardTitle className="text-base font-semibold">{title}</CardTitle>
+            <CardDescription className="text-xs">{subtitle}</CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="px-5 pt-0">
+        <Separator className="my-4 opacity-60" />
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-muted-foreground">Questions</span>
+          <span className="font-semibold text-[var(--primary-foreground)]">
+            10+
+          </span>
+        </div>
+        <div className="mt-2 flex items-center justify-between text-sm">
+          <span className="text-muted-foreground">Est. time</span>
+          <span className="font-semibold text-[var(--primary-foreground)]">
+            5–7 min
+          </span>
+        </div>
+      </CardContent>
+      <CardFooter className="pt-0">
+        <Button
+          variant="outline"
+          className="w-full border-[var(--border)] hover:bg-accent/50"
+          aria-label={`Explore ${title} quiz`}
+        >
+          Preview
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}


### PR DESCRIPTION


PR description
Summary
- Introduces a gorgeous, theme-aware Quiz section to signal dedicated Web3 learning.
- Extracts reusable QuizCard for category tiles (DeFi Basics, NFTs & Culture, Layer 2s).
- Aligns fully with existing design tokens and UI primitives.

Changes
- Added/updated:
  - Quiz.tsx — main section with header, category grid, CTA.
  - QuizCard.tsx — reusable category card component.
  - page.tsx — renders Quiz section on the landing page.
- Compliance:
  - Uses only existing CSS variables from globals.css (no hardcoded colors).
  - No new color variables introduced.
  - Uses existing Button/Card/Separator components.

Why
- Gives users a clear reflection that the app has dedicated Web3 quiz functionality, matching the landing’s aesthetic and dark/light themes.

Accessibility
- Buttons include aria-labels for screen readers.
- Decorative icons use aria-hidden.
- Sufficient contrast inherited from theme tokens.


<img width="1848" height="836" alt="image" src="https://github.com/user-attachments/assets/c0f85672-27a9-41e9-958a-c5391bbba3b5" />

