### PR TITLE
fix: rename Button component to CtaButton and streamline props f…

### DIFF
--- a/src/components/Section/CTA/CTA.tsx
+++ b/src/components/Section/CTA/CTA.tsx
@@ -5,24 +5,21 @@ const containerStyle: React.CSSProperties = {
   border: "1px solid var(--color-cta-border)",
 };
 
-
-type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+type CtaButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: "primary" | "secondary";
   "aria-label"?: string;
 };
 
-function Button({
+function CtaButton({
   children,
   variant = "primary",
   "aria-label": ariaLabel,
   onClick,
-}: ButtonProps) {
+  ...rest
+}: CtaButtonProps) {
   const base =
-    "rounded-md px-6 py-2 font-medium shadow-md transition-transform transition duration-200 ease-in-out";
-};
-
-function Button({ children, variant = "primary", aria, onClick }: ButtonProps) {
-  const variants: Record<string, string> = {
+    "rounded-md px-6 py-2 font-medium shadow-md transition-transform duration-200 ease-in-out";
+  const variants: Record<Required<CtaButtonProps>["variant"], string> = {
     primary:
       "bg-[var(--color-cta-primary-bg)] text-[var(--color-cta-primary-text)] hover:bg-[var(--color-cta-primary-hover-bg)]",
     secondary:
@@ -35,6 +32,7 @@ function Button({ children, variant = "primary", aria, onClick }: ButtonProps) {
       className={`${base} ${variants[variant]} hover:scale-105`}
       aria-label={ariaLabel}
       onClick={onClick}
+      {...rest}
     >
       {children}
     </button>
@@ -63,15 +61,15 @@ export default function CTA() {
       </p>
 
       <div className="flex justify-center gap-4">
-        <Button aria-label="Get Started Now - Begin learning DeFi">
+        <CtaButton aria-label="Get Started Now - Begin learning DeFi">
           Get Started Now
-        </Button>
-        <Button
+        </CtaButton>
+        <CtaButton
           variant="secondary"
           aria-label="View Demo - Preview the quiz platform"
         >
           View Demo
-        </Button>
+        </CtaButton>
       </div>
     </section>
   );


### PR DESCRIPTION

## PR description
Summary
- Fixes Next.js build error “the name `Button` is defined multiple times” in CTA.tsx.

What changed
- Removed duplicate local `Button` definitions.
- Introduced a single local component `CtaButton` with proper typing and props.
- Updated CTA usage to use `CtaButton`.
- Cleaned up classes (no duplicate transition), and wired `aria-label` correctly.

Why
- Duplicate component names in the same file caused compilation failure and potential naming conflicts with the shared `ui/button` component.

Impact
- No UI/UX changes expected; resolves the dev/build error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - CTA buttons now accept additional HTML attributes for greater flexibility in interactions.

- Accessibility
  - More consistent aria-label handling to improve screen reader support.

- Style
  - Subtle transition adjustments for smoother button hover/press animations.

- Refactor
  - Internal cleanup and stronger typing for the CTA component with no change to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->