### PR TITLE
feat: add ReadyToStartTitle component with Header integration and prelude prop

### DIFF
--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -1,7 +1,9 @@
+import type { ReactNode } from "react";
+
 type HeaderProps = {
   title: string;
   subtitle?: string;
-  prelude?: React.ReactNode;
+  prelude?: ReactNode;
 };
 
 export default function Header({ title, subtitle, prelude }: HeaderProps) {

--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -1,14 +1,18 @@
 type HeaderProps = {
   title: string;
   subtitle?: string;
+  prelude?: React.ReactNode;
 };
 
-export default function Header({ title, subtitle }: HeaderProps) {
+export default function Header({ title, subtitle, prelude }: HeaderProps) {
   return (
     <header
       className="bg-sidebar-primary-foreground p-4"
       aria-label="Page Header"
     >
+      {prelude && (
+        <div className="w-full flex justify-center mb-6 md:mb-8">{prelude}</div>
+      )}
       <h1 className="text-4xl font-bold text-center bg-gradient-to-r from-ring to-popover bg-clip-text text-transparent mb-1">
         {title}
       </h1>

--- a/src/components/Section/ReadyToStart/ReadyToStartTitle.tsx
+++ b/src/components/Section/ReadyToStart/ReadyToStartTitle.tsx
@@ -1,0 +1,22 @@
+import Header from "@/components/Header/header";
+import { Sparkles } from "lucide-react";
+
+export default function ReadyToStartTitle() {
+  return (
+    <div className="mb-8 md:mb-12 lg:mb-16">
+      <Header
+        prelude={
+          <span className="flex items-center px-3 py-1.5 gap-1.5 text-sm font-medium rounded-full bg-sidebar-primary-foreground text-foreground border border-chart-2 shadow-sm hover:shadow-md transition-shadow duration-200">
+            <span className="text-primary">
+              <Sparkles className="w-4 h-4 md:w-5 md:h-5" aria-hidden />
+            </span>
+            <span className="sr-only">Ready to start</span>
+            <span aria-hidden>Ready to start your DeFi journey?</span>
+          </span>
+        }
+        title="Join thousands of DeFi learners today"
+        subtitle="Start your journey into decentralized finance with interactive quizzes, earn rewards, and become part of the most engaged crypto education community on Farcaster."
+      />
+    </div>
+  );
+}


### PR DESCRIPTION

### PR description
Summary
- Add a `ReadyToStartTitle` component and integrate a prelude (badge) into the shared `Header` so the badge, title and subtitle render inside the same header background.

What changed
- header.tsx
  - Add optional `prelude?: React.ReactNode` prop.
  - Render `prelude` above title inside the header container so any badge/content shares the header background.
- ReadyToStartTitle.tsx
  - Create `ReadyToStartTitle` that passes the badge JSX as `prelude` into `Header`.
  - Badge styling reuses existing tokens/classes (no new CSS variables or hardcoded colors).

Why
- Previously the badge was outside the header container which caused mismatched backgrounds. Moving the badge into the header via `prelude` ensures visual consistency and reuses the shared header styling.

<img width="855" height="299" alt="image" src="https://github.com/user-attachments/assets/e3b2adde-0fda-47ed-b984-1c44f070271d" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Header accepts an optional prelude element displayed above the title for badges or labels.
  - Added a new “Ready to start” title section with a sparkles badge and a prominent headline and subtitle.

- **Style**
  - Centered prelude placement and responsive spacing for a cleaner, more engaging section header.

- **Accessibility**
  - Included descriptive, screen-reader-friendly text for the “Ready to start” badge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->