### PR TITLE
feat: add ReadyToStartCTA component with buttons 

### DIFF
--- a/src/components/Section/CTA/ReadyToStartCTA.tsx
+++ b/src/components/Section/CTA/ReadyToStartCTA.tsx
@@ -1,54 +1,64 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 
-export default function ReadyToStartCTA() {
+type ReadyToStartCTAProps = {
+  onGetStarted?: () => void;
+  onViewDemo?: () => void;
+  getStartedLabel?: string;
+  viewDemoLabel?: string;
+};
+
+export default function ReadyToStartCTA({
+  onGetStarted,
+  onViewDemo,
+  getStartedLabel = "Get Started Now",
+  viewDemoLabel = "View Demo",
+}: ReadyToStartCTAProps) {
   return (
     <div className="flex flex-col items-center gap-4">
       <div className="flex justify-center gap-4">
-        <Button
-          aria-label="Get Started Now - Begin learning DeFi"
-          className="px-6"
-        >
-          Get Started Now
+        <Button type="button" className="px-6" onClick={onGetStarted}>
+          {getStartedLabel}
         </Button>
 
         <Button
-          aria-label="View Demo - Preview the quiz platform"
+          type="button"
           variant="secondary"
           className="px-6"
+          onClick={onViewDemo}
         >
-          View Demo
+          {viewDemoLabel}
         </Button>
       </div>
 
-      <div
+      <ul
         className="mt-4 flex items-center justify-center gap-6 text-sm"
         style={{ color: "var(--color-cta-description)" }}
       >
-        <div className="flex items-center gap-2">
+        <li className="flex items-center gap-2">
           <span
             className="inline-block w-2 h-2 rounded-full bg-[var(--color-cta-primary-bg)]"
             aria-hidden
           />
           <span>Free to start</span>
-        </div>
+        </li>
 
-        <div className="flex items-center gap-2">
+        <li className="flex items-center gap-2">
           <span
             className="inline-block w-2 h-2 rounded-full bg-[var(--color-cta-primary-bg)]"
             aria-hidden
           />
           <span>No credit card required</span>
-        </div>
+        </li>
 
-        <div className="flex items-center gap-2">
+        <li className="flex items-center gap-2">
           <span
             className="inline-block w-2 h-2 rounded-full bg-[var(--color-cta-primary-bg)]"
             aria-hidden
           />
           <span>Instant access</span>
-        </div>
-      </div>
+        </li>
+      </ul>
     </div>
   );
 }

--- a/src/components/Section/CTA/ReadyToStartCTA.tsx
+++ b/src/components/Section/CTA/ReadyToStartCTA.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+
+export default function ReadyToStartCTA() {
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="flex justify-center gap-4">
+        <Button
+          aria-label="Get Started Now - Begin learning DeFi"
+          className="px-6"
+        >
+          Get Started Now
+        </Button>
+
+        <Button
+          aria-label="View Demo - Preview the quiz platform"
+          variant="secondary"
+          className="px-6"
+        >
+          View Demo
+        </Button>
+      </div>
+
+      <div
+        className="mt-4 flex items-center justify-center gap-6 text-sm"
+        style={{ color: "var(--color-cta-description)" }}
+      >
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-block w-2 h-2 rounded-full bg-[var(--color-cta-primary-bg)]"
+            aria-hidden
+          />
+          <span>Free to start</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-block w-2 h-2 rounded-full bg-[var(--color-cta-primary-bg)]"
+            aria-hidden
+          />
+          <span>No credit card required</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-block w-2 h-2 rounded-full bg-[var(--color-cta-primary-bg)]"
+            aria-hidden
+          />
+          <span>Instant access</span>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
###  PR description
- Summary
  - Adds a new `ReadyToStartCTA` component that renders the primary CTA pair and three short feature points (Free to start, No credit card required, Instant access). This component is standalone so it can be imported/used wherever needed without altering the existing `CTA` component.

- What  changed
  - Added: ReadyToStartCTA.tsx
  - No changes to: CTA.tsx (left intact per request)
  - Uses existing UI `Button` (button.tsx) to keep styling consistent and accessible (aria-labels included).

- Why
  - Separates the “ready to start” action area into its own component for reuse and clearer structure. Matches the provided design: a centered button row and three inline bullet points below.



- PR checklist
  - [x] Component added (`ReadyToStartCTA.tsx`)
  - [x] Buttons use existing `Button` and include `aria-label`s
  - [x] Three descriptive points included
  - [x] CTA.tsx unchanged as requested

<img width="797" height="155" alt="image" src="https://github.com/user-attachments/assets/2f9aeceb-ca15-42c3-80d3-c2256ae1d626" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Ready to Start” call-to-action section with two buttons (primary and secondary) with customizable labels (defaults: “Get Started Now”, “View Demo”).
  * Shows inline quick benefits: “Free to start”, “No credit card required”, and “Instant access,” each with a visual indicator and descriptive text styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->