### PR TITLE
feat: add QuizCardPreview component for displaying quiz details and sample questions

### DIFF
--- a/src/components/FeatureFooter/featureFooter.tsx
+++ b/src/components/FeatureFooter/featureFooter.tsx
@@ -18,7 +18,7 @@ export default function Footer({
     <footer
       className={cn(
         "group relative flex flex-col items-center justify-center gap-4 text-center",
-        "py-8 transition-all duration-300 ease-out",
+        "py-6 transition-all duration-300 ease-out",
         className
       )}
     >

--- a/src/components/Section/Quiz/Quiz.tsx
+++ b/src/components/Section/Quiz/Quiz.tsx
@@ -3,8 +3,25 @@
 import { Button } from "@/components/ui/button";
 import { Brain, Wallet, Network, Image as ImageIcon } from "lucide-react";
 import QuizCard from "./QuizCard";
+// Import the modal component for quiz card previews
+import QuizCardPreview from "./QuizCardPreview";
+import React, { useState } from "react";
 
 export default function Quiz() {
+  // State to track which quiz card is being previewed
+  const [preview, setPreview] = useState<{
+    title: string;
+    subtitle?: string;
+  } | null>(null);
+
+  // Handler to open the preview modal with quiz card details
+  const handlePreview = (title: string, subtitle?: string) => {
+    setPreview({ title, subtitle });
+  };
+
+  // Handler to close the preview modal
+  const closeModal = () => setPreview(null);
+
   return (
     <section className="w-full bg-[var(--background)]">
       <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-16 md:py-24">
@@ -25,6 +42,7 @@ export default function Quiz() {
         </p>
 
         {/* Top row: categories */}
+        {/* Quiz cards with preview functionality. Each card passes its details to the preview modal handler. */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-10 mb-10">
           <QuizCard
             icon={
@@ -32,6 +50,9 @@ export default function Quiz() {
             }
             title="DeFi Basics"
             subtitle="Lending, AMMs, governance"
+            onPreview={() =>
+              handlePreview("DeFi Basics", "Lending, AMMs, governance")
+            }
           />
           <QuizCard
             icon={
@@ -42,6 +63,9 @@ export default function Quiz() {
             }
             title="NFTs & Culture"
             subtitle="Ownership, royalties, metadata"
+            onPreview={() =>
+              handlePreview("NFTs & Culture", "Ownership, royalties, metadata")
+            }
           />
           <QuizCard
             icon={
@@ -49,6 +73,7 @@ export default function Quiz() {
             }
             title="Layer 2s"
             subtitle="Rollups, bridges, gas"
+            onPreview={() => handlePreview("Layer 2s", "Rollups, bridges, gas")}
           />
         </div>
 
@@ -62,6 +87,14 @@ export default function Quiz() {
           </p>
         </div>
       </div>
+      {/* Preview Modal: Shows when a quiz card's Preview button is clicked */}
+      {preview && (
+        <QuizCardPreview
+          title={preview.title}
+          subtitle={preview.subtitle}
+          onClose={closeModal}
+        />
+      )}
     </section>
   );
 }

--- a/src/components/Section/Quiz/QuizCardPreview.tsx
+++ b/src/components/Section/Quiz/QuizCardPreview.tsx
@@ -1,0 +1,87 @@
+// Sample questions for demonstration in the preview modal
+const sampleQuestions = [
+  "What is an AMM in DeFi?",
+  "How do NFT royalties work?",
+  "What is the purpose of a blockchain bridge?",
+  "How can you secure your crypto wallet?",
+  "What is a rollup in Layer 2 scaling?",
+];
+import React from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+
+// Props for QuizCardPreview modal
+interface QuizCardPreviewProps {
+  title: string;
+  subtitle?: string;
+  onClose: () => void;
+  questions?: string[];
+}
+
+// QuizCardPreview modal component
+// Shows quiz title, subtitle, and sample questions. Tap anywhere outside the card or the close button to close.
+const QuizCardPreview: React.FC<QuizCardPreviewProps> = ({
+  title,
+  subtitle,
+  onClose,
+  questions = sampleQuestions,
+}) => {
+  return (
+    // Overlay: closes modal when clicked
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--popover-foreground)]/40"
+      onClick={onClose}
+      aria-label="Close preview overlay"
+    >
+      <Card
+        className="relative min-w-[300px] max-w-xs text-center shadow-lg bg-[var(--sidebar)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Close button */}
+        <button
+          className="absolute top-2 right-2 font-bold text-[var(--muted-foreground)] hover:text-[var(--foreground)] text-xl"
+          onClick={onClose}
+          aria-label="Close preview"
+        >
+          x
+        </button>
+        <CardHeader>
+          <CardTitle className="text-[var(--primary)] mb-2">{title}</CardTitle>
+          {subtitle && (
+            <CardDescription className="mb-2">{subtitle}</CardDescription>
+          )}
+        </CardHeader>
+        <CardContent>
+          <p className="text-xs text-[var(--muted-foreground)] mb-2">
+            This is a quick preview of the quiz topic.
+          </p>
+          {/* Sample questions */}
+          {questions.length > 0 && (
+            <div className="mt-4 text-left">
+              <div className="text-sm font-semibold mb-2 text-[var(--primary)]">
+                Sample Questions:
+              </div>
+              <ul className="list-disc pl-5 space-y-1">
+                {questions.map((q, i) => (
+                  <li
+                    key={i}
+                    className="text-xs text-[var(--muted-foreground)] font-bold"
+                  >
+                    {q}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default QuizCardPreview;

--- a/src/components/Section/Quiz/QuizCardPreview.tsx
+++ b/src/components/Section/Quiz/QuizCardPreview.tsx
@@ -31,15 +31,33 @@ const QuizCardPreview: React.FC<QuizCardPreviewProps> = ({
   onClose,
   questions = sampleQuestions,
 }) => {
+  // Accessibility: unique title id for aria-labelledby
+  const titleId = React.useId();
+  // Accessibility & UX: Esc-to-close and background scroll lock
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = prev;
+    };
+  }, [onClose]);
   return (
     // Overlay: closes modal when clicked
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--popover-foreground)]/40"
       onClick={onClose}
-      aria-label="Close preview overlay"
+      aria-hidden="true"
     >
       <Card
         className="relative min-w-[300px] max-w-xs text-center shadow-lg bg-[var(--sidebar)]"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
         onClick={(e) => e.stopPropagation()}
       >
         {/* Close button */}
@@ -51,7 +69,9 @@ const QuizCardPreview: React.FC<QuizCardPreviewProps> = ({
           x
         </button>
         <CardHeader>
-          <CardTitle className="text-[var(--primary)] mb-2">{title}</CardTitle>
+          <CardTitle id={titleId} className="text-[var(--primary)] mb-2">
+            {title}
+          </CardTitle>
           {subtitle && (
             <CardDescription className="mb-2">{subtitle}</CardDescription>
           )}


### PR DESCRIPTION

**PR Description:**  
- Introduced `QuizCardPreview` modal component to show quiz title, subtitle, and a list of sample questions.
- Supports tap-anywhere-to-close and close button functionality.
- Uses shared `Card` UI for consistent styling and sidebar background.
- Added concise comments to highlight important logic and structure.
- Sample questions are bolded for emphasis and can be customized via props.

<img width="1342" height="633" alt="image" src="https://github.com/user-attachments/assets/59f68cf5-c7c1-49ab-8645-28c1219d250f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Ready to Start” call-to-action with primary and secondary buttons (Get Started, View Demo).
  * Introduced interactive quiz previews via a modal showing titles, subtitles, and sample questions.

* **Style**
  * Reduced footer vertical padding for a more compact appearance.
  * Simplified footer grid/responsiveness and item alignment.
  * Enhanced quiz card visuals: borders, hover effects, background states, subtle scale.
  * Increased quiz grid spacing and refined CTA button styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->