### PR TITLE
Feat/add mobile navigation menu

### DIFF
--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -63,7 +63,7 @@ const Navigation = () => {
 
   return (
     <>
-  <style>{sparkleKeyframes}</style>
+      <style>{sparkleKeyframes}</style>
       <nav className="fixed top-0 left-0 right-0 z-50 bg-gradient-to-r from-hero-gradient-from/80 to-hero-gradient-to/80 backdrop-blur-md border-b border-border/20">
         <div className="container mx-auto px-4">
           <div className="flex items-center justify-between h-16">
@@ -127,6 +127,48 @@ const Navigation = () => {
           </div>
         </div>
       </nav>
+
+      {/* Mobile Navigation */}
+      {isMenuOpen && (
+        <div className="md:hidden mt-16 py-4 border-t border-border/20 bg-background/90 backdrop-blur-sm">
+          <div className="container mx-auto px-4">
+            <div className="flex flex-col space-y-4">
+              <a
+                href="#features"
+                className="text-foreground hover:text-foreground/80 transition-colors"
+              >
+                Features
+              </a>
+              <a
+                href="#testimonials"
+                className="text-foreground hover:text-foreground/80 transition-colors"
+              >
+                Testimonials
+              </a>
+              <a
+                href="#stats"
+                className="text-foreground hover:text-foreground/80 transition-colors"
+              >
+                Stats
+              </a>
+              <a
+                href="#faq"
+                className="text-foreground hover:text-foreground/80 transition-colors"
+              >
+                FAQ
+              </a>
+              <div className="flex flex-col space-y-2 pt-4">
+                <Button variant="ghost" size="sm">
+                  Sign In
+                </Button>
+                <Button variant="gradient" size="sm">
+                  Get Started
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 };

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -117,6 +117,8 @@ const Navigation = () => {
               className="md:hidden p-2"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               aria-label={isMenuOpen ? "Close menu" : "Open menu"}
+              aria-expanded={isMenuOpen}
+              aria-controls="mobile-menu"
             >
               {isMenuOpen ? (
                 <X className="w-6 h-6" />
@@ -130,7 +132,10 @@ const Navigation = () => {
 
       {/* Mobile Navigation */}
       {isMenuOpen && (
-        <div className="md:hidden mt-16 py-4 border-t border-border/20 bg-background/90 backdrop-blur-sm">
+        <div
+          id="mobile-menu"
+          className="md:hidden mt-16 py-4 border-t border-border/20 bg-background/90 backdrop-blur-sm"
+        >
           <div className="container mx-auto px-4">
             <div className="flex flex-col space-y-4">
               <a

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -11,6 +11,8 @@ const buttonVariants = cva(
       variant: {
         default:
           "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        gradient:
+          "bg-gradient-to-r from-[var(--color-hero-gradient-from)] to-[var(--color-hero-gradient-to)] text-background shadow-xs hover:opacity-95",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
@@ -33,7 +35,7 @@ const buttonVariants = cva(
       size: "default",
     },
   }
-)
+);
 
 function Button({
   className,
@@ -43,9 +45,9 @@ function Button({
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot : "button"
+  const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
@@ -53,7 +55,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -49,11 +49,21 @@ function Button({
   }) {
   const Comp = asChild ? Slot : "button";
 
+  const variantClasses = buttonVariants({ variant, size });
+
+  // If not rendering as child, ensure the element is a safe button that won't
+  // implicitly submit a surrounding form by defaulting type to "button" when
+  // no type is provided by the consumer.
+  const safeProps = { ...(props as Record<string, unknown>) };
+  if (!asChild && safeProps.type === undefined) {
+    (safeProps as Record<string, unknown>).type = "button";
+  }
+
   return (
     <Comp
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props}
+      className={cn(variantClasses, className)}
+      {...(safeProps as React.ComponentProps<"button">)}
     />
   );
 }


### PR DESCRIPTION
### Summary
- Adds a subtle sparkle animation to the navbar logo and implements a mobile-responsive navigation menu with clearer background/contrast.
- Improves mobile CTAs with a polished gradient/animation and makes the CTA style available via the shared `Button` component.

What changed
- navbar.tsx — Added sparkle keyframes, mobile menu markup, improved mobile nav visibility (background, spacing, blur), and mobile CTA styling/behavior.
- button.tsx — Added `gradient` variant to centralize the hero/CTA gradient style.
- Inline component CSS retained (no edits to global.css); animations respect `prefers-reduced-motion`.

Why
- Mobile navigation items were hard to read and the mobile CTAs lacked polish. These changes improve discoverability, accessibility, and visual polish while keeping styles centralized and theme-driven (CSS variables).

Files touched
- navbar.tsx — navbar markup, mobile nav, inline animations
- button.tsx — added `gradient` variant to `buttonVariants`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a subtle sparkle animation to the logo with motion-preference support.
  - Introduced a new gradient button style; desktop “Get Started” now uses it.

- UI/Design
  - Simplified logo area by removing the tinted background for a cleaner look.
  - Injected animation styles so the sparkle runs consistently across views.
  - Preserved navigation links and FAQ while refining visual consistency.

- Accessibility
  - Respects reduced-motion settings and marks decorative icon as hidden from assistive tech.

- Responsive/Mobile
  - Mobile menu now renders below the header when opened; mobile “Get Started” uses the gradient button.

- Bug Fixes
  - Prevented unintended form submissions from primary buttons by defaulting button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->