### PR TITLE
feat: add Testimonial component with community feedback section

### DIFF
--- a/src/app/(landing)/Testimonial/Testimonial.tsx
+++ b/src/app/(landing)/Testimonial/Testimonial.tsx
@@ -1,0 +1,39 @@
+import { Badge } from "@/components/ui/badge";
+import { Quote } from "lucide-react";
+
+const Testimonial = () => {
+  return (
+    <section
+      id="testimonials"
+      className="py-24 bg-gradient-to-b from-background to-card/30"
+    >
+      <div className="container mx-auto px-4">
+        <div className="text-center mb-16">
+          <Badge className="bg-about-badge-bg text-about-badge-text border-about-badge-text/20 px-4 py-2 text-sm font-medium mb-6 inline-flex items-center justify-center">
+            <Quote className="w-4 h-4 mr-2" />
+            What Our Community Says
+          </Badge>
+
+          <h2 className="text-4xl lg:text-5xl font-bold mb-6">
+            Trusted by{" "}
+            <span className="bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
+              Thousands
+            </span>{" "}
+            of Learners
+          </h2>
+
+          <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
+            Join the community of DeFi enthusiasts who are mastering crypto
+            through our platform
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-8">
+          {/* Testimonial cards will be added here in a future PR */}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Testimonial;


### PR DESCRIPTION
### PR description
- Summary
  - Add a layout-only Testimonial section for the landing page. The component renders the exact badge text, title and subtitle and includes a placeholder comment where testimonial cards will be added later.
- Files changed
  - Testimonial.tsx
- What  changed
  - Rendered the badge: "What Our Community Says" (with `Quote` icon).
  - Added title: "Trusted by Thousands of Learners" where the word "Thousands" uses the same gradient technique as the "Works" span in HowItWorks.tsx (`bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent`).
  - Added subtitle: "Join the community of DeFi enthusiasts who are mastering crypto through our platform".
  - Removed any hardcoded testimonial cards — added a clear placeholder comment: `/* Testimonial cards will be added here in a future PR */`.
  - No global CSS or other file changes.
- Why
  - Prepare the landing layout/header for testimonials now so the visual header is correct and future PRs can add cards without touching the header behavior.
