### PR TITLE
feat: add partnership component

### DIFF
--- a/src/app/(landing)/Partnership/Partnership.tsx
+++ b/src/app/(landing)/Partnership/Partnership.tsx
@@ -1,0 +1,34 @@
+import { Badge } from "@/components/ui/badge";
+
+const Partnership = () => {
+  return (
+    <section className="py-16">
+      <div className="container mx-auto px-4">
+        <div className="text-center">
+          <Badge
+            variant="secondary"
+            className="mb-4 px-4 py-2 text-sm font-medium glass-effect"
+          >
+            Trusted Ecosystem
+          </Badge>
+
+          <h2 className="text-3xl md:text-4xl font-bold mb-2">
+            Powering{" "}
+            <span className="bg-gradient-to-r from-primary via-accent to-primary bg-clip-text text-transparent">
+              DeFi Education
+            </span>
+          </h2>
+
+          <p className="text-base text-muted-foreground max-w-2xl mx-auto leading-relaxed">
+            Learn about the most important protocols and platforms in the DeFi
+            ecosystem through hands-on experience
+          </p>
+
+          {/* partnership card will be implemented here */}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Partnership;

--- a/src/app/(landing)/Statistics/Statistics.tsx
+++ b/src/app/(landing)/Statistics/Statistics.tsx
@@ -3,50 +3,70 @@ import { Badge } from "@/components/ui/badge";
 
 const Statistics: React.FC = () => {
   return (
-    <section aria-labelledby="statistics-heading" className="py-20 relative overflow-hidden">
+    <section
+      aria-labelledby="statistics-heading"
+      className="py-20 relative overflow-hidden"
+    >
+      {/* Background */}
+      <div className="absolute inset-0 gradient-secondary opacity-50" />
+      <div className="absolute inset-0 bg-grid-pattern opacity-20" />
+
       <div className="container mx-auto px-4 relative">
         <div className="text-center mb-12">
-          <Badge variant="secondary" className="mb-4 px-4 py-2 text-sm font-medium glass-effect">
+          <Badge
+            variant="secondary"
+            className="mb-4 px-4 py-2 text-sm font-medium text-secondary-foreground bg-background/60 dark:bg-background/30 backdrop-blur-sm rounded-md shadow-sm"
+          >
             Platform Metrics
           </Badge>
 
-          <h2 id="statistics-heading" className="text-4xl md:text-5xl font-bold mb-6">
-            Powering DeFi Education{' '}
+          <h2
+            id="statistics-heading"
+            className="text-4xl md:text-5xl font-bold mb-6"
+          >
+            Powering DeFi Education{" "}
             <span className="bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
               Globally
             </span>
           </h2>
 
           <p className="text-xl text-muted-foreground max-w-2xl mx-auto leading-relaxed">
-            Real numbers from our thriving ecosystem of learners, educators, and DeFi enthusiasts
+            Real numbers from our thriving ecosystem of learners, educators, and
+            DeFi enthusiasts
           </p>
         </div>
 
         {/* Placeholder grid for future statistics cards */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mt-12">
-          <div className="p-8 rounded-lg border bg-card/50 glass-effect text-center">
+          <div className="p-8 rounded-lg border bg-background/60 dark:bg-background/30 backdrop-blur-sm text-center">
             <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-gradient-to-r from-primary/20 to-accent/20 flex items-center justify-center">
               {/* Icon placeholder */}
               <div className="w-8 h-8 rounded-full bg-primary/60" />
             </div>
             <h3 className="text-2xl font-bold mb-2">15,000+</h3>
-            <p className="text-sm font-medium text-muted-foreground">Active Learners</p>
+            <p className="text-sm font-medium text-muted-foreground">
+              Active Learners
+            </p>
           </div>
 
-          <div className="p-8 rounded-lg border bg-card/50 glass-effect text-center">
+          <div className="p-8 rounded-lg border bg-background/60 dark:bg-background/30 backdrop-blur-sm text-center">
             <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-gradient-to-r from-primary/20 to-accent/20 flex items-center justify-center">
               <div className="w-8 h-8 rounded-full bg-primary/60" />
             </div>
             <h3 className="text-2xl font-bold mb-2">200+</h3>
-            <p className="text-sm font-medium text-muted-foreground">Interactive Quizzes</p>
+            <p className="text-sm font-medium text-muted-foreground">
+              Interactive Quizzes
+            </p>
           </div>
 
-          <div className="p-8 rounded-lg border bg-card/50 glass-effect text-center">
+          <div className="p-8 rounded-lg border bg-background/60 dark:bg-background/30 backdrop-blur-sm text-center">
             <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-gradient-to-r from-primary/20 to-accent/20 flex items-center justify-center">
               <div className="w-8 h-8 rounded-full bg-primary/60" />
             </div>
             <h3 className="text-2xl font-bold mb-2">85+</h3>
-            <p className="text-sm font-medium text-muted-foreground">Unique Badges</p>
+            <p className="text-sm font-medium text-muted-foreground">
+              Unique Badges
+            </p>
           </div>
         </div>
       </div>

--- a/src/app/(landing)/Statistics/Statistics.tsx
+++ b/src/app/(landing)/Statistics/Statistics.tsx
@@ -1,73 +1,113 @@
 import React from "react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Users, BookOpen, Award, Coins, TrendingUp, Globe } from "lucide-react";
 
 const Statistics: React.FC = () => {
+  const stats = [
+    {
+      icon: Users,
+      number: "15,000+",
+      title: "Active Learners",
+      description: "Growing community of DeFi enthusiasts",
+    },
+    {
+      icon: BookOpen,
+      number: "200+",
+      title: "Interactive Quizzes",
+      description: "Covering all major DeFi protocols",
+    },
+    {
+      icon: Award,
+      number: "85+",
+      title: "Unique Badges",
+      description: "Collectible achievements to unlock",
+    },
+    {
+      icon: Coins,
+      number: "1M+",
+      title: "Tokens Earned",
+      description: "Rewarded to our community",
+    },
+    {
+      icon: TrendingUp,
+      number: "95%",
+      title: "Completion Rate",
+      description: "Students who finish courses",
+    },
+    {
+      icon: Globe,
+      number: "50+",
+      title: "Countries",
+      description: "Global DeFi education reach",
+    },
+  ];
+
   return (
     <section
       aria-labelledby="statistics-heading"
-      className="py-20 relative overflow-hidden"
+      className="py-16 lg:py-24  relative overflow-hidden"
     >
       {/* Background */}
-      <div className="absolute inset-0 gradient-secondary opacity-50" />
-      <div className="absolute inset-0 bg-grid-pattern opacity-20" />
+      <div className="absolute inset-0 bg-gradient-to-b from-muted/50 to-transparent" />
 
-      <div className="container mx-auto px-4 relative">
-        <div className="text-center mb-12">
+      <div className="container mx-auto px-4 relative max-w-6xl">
+        {/* Header Section */}
+        <div className="text-center mb-16">
           <Badge
             variant="secondary"
-            className="mb-4 px-4 py-2 text-sm font-medium text-secondary-foreground bg-background/60 dark:bg-background/30 backdrop-blur-sm rounded-md shadow-sm"
+            className="mb-6 px-4 py-2 text-sm font-medium bg-muted/60 text-muted-foreground border-0 rounded-full"
           >
-            Platform Metrics
+            📊 Platform Metrics
           </Badge>
 
           <h2
             id="statistics-heading"
-            className="text-4xl md:text-5xl font-bold mb-6"
+            className="text-4xl lg:text-5xl xl:text-6xl font-bold mb-6 tracking-tight"
           >
             Powering DeFi Education{" "}
-            <span className="bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
+            <span className="bg-gradient-to-r from-primary via-purple-500 to-primary bg-clip-text text-transparent">
               Globally
             </span>
           </h2>
 
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto leading-relaxed">
+          <p className="text-lg lg:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
             Real numbers from our thriving ecosystem of learners, educators, and
             DeFi enthusiasts
           </p>
         </div>
 
-        {/* Placeholder grid for future statistics cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mt-12">
-          <div className="p-8 rounded-lg border bg-background/60 dark:bg-background/30 backdrop-blur-sm text-center">
-            <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-gradient-to-r from-primary/20 to-accent/20 flex items-center justify-center">
-              {/* Icon placeholder */}
-              <div className="w-8 h-8 rounded-full bg-primary/60" />
-            </div>
-            <h3 className="text-2xl font-bold mb-2">15,000+</h3>
-            <p className="text-sm font-medium text-muted-foreground">
-              Active Learners
-            </p>
-          </div>
+        {/* Statistics Grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8 mb-16">
+          {stats.map((stat, index) => {
+            const IconComponent = stat.icon;
+            return (
+              <div
+                key={index}
+                className="group relative p-8 rounded-2xl backdrop-blur-sm text-center transition-all duration-300 hover:shadow-lg hover:-translate-y-1 hover:bg-background/80"
+              >
+                {/* Icon */}
+                <div className="w-16 h-16 mx-auto mb-6 rounded-2xl bg-primary/10 flex items-center justify-center group-hover:bg-primary/20 transition-colors">
+                  <IconComponent className="w-8 h-8 text-primary" />
+                </div>
 
-          <div className="p-8 rounded-lg border bg-background/60 dark:bg-background/30 backdrop-blur-sm text-center">
-            <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-gradient-to-r from-primary/20 to-accent/20 flex items-center justify-center">
-              <div className="w-8 h-8 rounded-full bg-primary/60" />
-            </div>
-            <h3 className="text-2xl font-bold mb-2">200+</h3>
-            <p className="text-sm font-medium text-muted-foreground">
-              Interactive Quizzes
-            </p>
-          </div>
+                {/* Number */}
+                <h3 className="text-3xl lg:text-4xl font-bold mb-3 text-primary">
+                  {stat.number}
+                </h3>
 
-          <div className="p-8 rounded-lg border bg-background/60 dark:bg-background/30 backdrop-blur-sm text-center">
-            <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-gradient-to-r from-primary/20 to-accent/20 flex items-center justify-center">
-              <div className="w-8 h-8 rounded-full bg-primary/60" />
-            </div>
-            <h3 className="text-2xl font-bold mb-2">85+</h3>
-            <p className="text-sm font-medium text-muted-foreground">
-              Unique Badges
-            </p>
-          </div>
+                {/* Title */}
+                <h4 className="text-lg font-semibold mb-2 text-foreground">
+                  {stat.title}
+                </h4>
+
+                {/* Description */}
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {stat.description}
+                </p>
+              </div>
+            );
+          })}
         </div>
       </div>
     </section>

--- a/src/app/(landing)/Statistics/Statistics.tsx
+++ b/src/app/(landing)/Statistics/Statistics.tsx
@@ -66,7 +66,7 @@ const Statistics: React.FC = () => {
             className="text-4xl lg:text-5xl xl:text-6xl font-bold mb-6 tracking-tight"
           >
             Powering DeFi Education{" "}
-            <span className="bg-gradient-to-r from-primary via-purple-500 to-primary bg-clip-text text-transparent">
+            <span className="bg-gradient-to-r from-primary via-accent to-primary bg-clip-text text-transparent">
               Globally
             </span>
           </h2>

--- a/src/app/(landing)/Statistics/Statistics.tsx
+++ b/src/app/(landing)/Statistics/Statistics.tsx
@@ -109,6 +109,25 @@ const Statistics: React.FC = () => {
             );
           })}
         </div>
+
+        {/* CTA: Join button + caption */}
+        <div className="flex flex-col items-center mt-4 mb-12 relative">
+          {/* Subtle decorative gradient behind the button that uses theme tokens (no hardcoded colors) */}
+          <div className="pointer-events-none absolute -inset-x-20 -bottom-8 h-36 rounded-full blur-3xl bg-gradient-to-r from-primary/20 to-transparent opacity-60 dark:from-primary/30" />
+
+          <Button
+            variant="gradient"
+            size="lg"
+            className="z-10 inline-flex items-center gap-3 text-base lg:text-lg lg:px-8 lg:py-3"
+          >
+            <Users className="w-5 h-5 lg:w-6 lg:h-6" />
+            Join the Revolution
+          </Button>
+
+          <p className="text-sm lg:text-base text-muted-foreground mt-3 max-w-2xl text-center">
+            Be part of the next generation of DeFi learners and builders
+          </p>
+        </div>
       </div>
     </section>
   );

--- a/src/app/(landing)/Statistics/Statistics.tsx
+++ b/src/app/(landing)/Statistics/Statistics.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Badge } from "@/components/ui/badge";
+
+const Statistics: React.FC = () => {
+  return (
+    <section aria-labelledby="statistics-heading" className="py-20 relative overflow-hidden">
+      <div className="container mx-auto px-4 relative">
+        <div className="text-center mb-12">
+          <Badge variant="secondary" className="mb-4 px-4 py-2 text-sm font-medium glass-effect">
+            Platform Metrics
+          </Badge>
+
+          <h2 id="statistics-heading" className="text-4xl md:text-5xl font-bold mb-6">
+            Powering DeFi Education{' '}
+            <span className="bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
+              Globally
+            </span>
+          </h2>
+
+          <p className="text-xl text-muted-foreground max-w-2xl mx-auto leading-relaxed">
+            Real numbers from our thriving ecosystem of learners, educators, and DeFi enthusiasts
+          </p>
+        </div>
+
+        {/* Placeholder grid for future statistics cards */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mt-12">
+          <div className="p-8 rounded-lg border bg-card/50 glass-effect text-center">
+            <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-gradient-to-r from-primary/20 to-accent/20 flex items-center justify-center">
+              {/* Icon placeholder */}
+              <div className="w-8 h-8 rounded-full bg-primary/60" />
+            </div>
+            <h3 className="text-2xl font-bold mb-2">15,000+</h3>
+            <p className="text-sm font-medium text-muted-foreground">Active Learners</p>
+          </div>
+
+          <div className="p-8 rounded-lg border bg-card/50 glass-effect text-center">
+            <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-gradient-to-r from-primary/20 to-accent/20 flex items-center justify-center">
+              <div className="w-8 h-8 rounded-full bg-primary/60" />
+            </div>
+            <h3 className="text-2xl font-bold mb-2">200+</h3>
+            <p className="text-sm font-medium text-muted-foreground">Interactive Quizzes</p>
+          </div>
+
+          <div className="p-8 rounded-lg border bg-card/50 glass-effect text-center">
+            <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-gradient-to-r from-primary/20 to-accent/20 flex items-center justify-center">
+              <div className="w-8 h-8 rounded-full bg-primary/60" />
+            </div>
+            <h3 className="text-2xl font-bold mb-2">85+</h3>
+            <p className="text-sm font-medium text-muted-foreground">Unique Badges</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Statistics;

--- a/src/app/(landing)/Statistics/Statistics.tsx
+++ b/src/app/(landing)/Statistics/Statistics.tsx
@@ -1,65 +1,70 @@
 import React from "react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Users, BookOpen, Award, Coins, TrendingUp, Globe } from "lucide-react";
 import StatisticsCard from "@/components/landing/StatisticsCard";
+import { Users, BookOpen, Award, Coins, TrendingUp, Globe } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type IconComponent = React.ComponentType<React.SVGProps<SVGSVGElement>>;
+
+const stats: Array<{
+  icon: IconComponent;
+  number: string;
+  title: string;
+  description?: string;
+}> = [
+  {
+    icon: Users,
+    number: "15,000+",
+    title: "Active Learners",
+    description: "Growing community of DeFi enthusiasts",
+  },
+  {
+    icon: BookOpen,
+    number: "200+",
+    title: "Interactive Quizzes",
+    description: "Covering all major DeFi protocols",
+  },
+  {
+    icon: Award,
+    number: "85+",
+    title: "Unique Badges",
+    description: "Collectible achievements to unlock",
+  },
+  {
+    icon: Coins,
+    number: "1M+",
+    title: "Tokens Earned",
+    description: "Rewarded to our community",
+  },
+  {
+    icon: TrendingUp,
+    number: "95%",
+    title: "Completion Rate",
+    description: "Students who finish courses",
+  },
+  {
+    icon: Globe,
+    number: "50+",
+    title: "Countries",
+    description: "Global DeFi education reach",
+  },
+];
 
 const Statistics: React.FC = () => {
-  const stats = [
-    {
-      icon: Users,
-      number: "15,000+",
-      title: "Active Learners",
-      description: "Growing community of DeFi enthusiasts",
-    },
-    {
-      icon: BookOpen,
-      number: "200+",
-      title: "Interactive Quizzes",
-      description: "Covering all major DeFi protocols",
-    },
-    {
-      icon: Award,
-      number: "85+",
-      title: "Unique Badges",
-      description: "Collectible achievements to unlock",
-    },
-    {
-      icon: Coins,
-      number: "1M+",
-      title: "Tokens Earned",
-      description: "Rewarded to our community",
-    },
-    {
-      icon: TrendingUp,
-      number: "95%",
-      title: "Completion Rate",
-      description: "Students who finish courses",
-    },
-    {
-      icon: Globe,
-      number: "50+",
-      title: "Countries",
-      description: "Global DeFi education reach",
-    },
-  ];
-
   return (
     <section
       aria-labelledby="statistics-heading"
-      className="py-16 lg:py-24  relative overflow-hidden"
+      className="py-16 lg:py-24 relative overflow-hidden"
     >
-      {/* Background */}
-      <div className="absolute inset-0 bg-gradient-to-b from-muted/50 to-transparent" />
+      <div className="absolute inset-0 bg-gradient-to-b from-muted/40 to-transparent pointer-events-none" />
 
-      <div className="container mx-auto px-4 relative max-w-6xl">
-        {/* Header Section */}
+      <div className="mx-auto px-4 relative max-w-6xl">
         <div className="text-center mb-16">
           <Badge
             variant="secondary"
-            className="mb-6 px-4 py-2 text-sm font-medium bg-muted/60 text-muted-foreground border-0 rounded-full"
+            className="mb-6 px-4 py-2 text-sm font-medium bg-muted/60 text-muted-foreground rounded-full border-0"
           >
-            📊 Platform Metrics
+            Platform Metrics
           </Badge>
 
           <h2
@@ -67,7 +72,7 @@ const Statistics: React.FC = () => {
             className="text-4xl lg:text-5xl xl:text-6xl font-bold mb-6 tracking-tight"
           >
             Powering DeFi Education{" "}
-            <span className="bg-gradient-to-r from-primary via-accent to-primary bg-clip-text text-transparent">
+            <span className="bg-gradient-to-r from-primary via-purple-500 to-primary bg-clip-text text-transparent">
               Globally
             </span>
           </h2>
@@ -78,13 +83,19 @@ const Statistics: React.FC = () => {
           </p>
         </div>
 
-        {/* Statistics Grid */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8 mb-16">
-          {stats.map((stat, index) => {
-            return <StatisticsCard key={index} stat={stat} />;
-          })}
+          {stats.map((s, i) => (
+            <StatisticsCard
+              key={s.title + i}
+              icon={s.icon}
+              number={s.number}
+              title={s.title}
+              description={s.description}
+            />
+          ))}
         </div>
 
+        {/* CTA intentionally removed per design — keep this area for future inline CTA if needed */}
         {/* CTA: Join button + caption */}
         <div className="flex flex-col items-center mt-4 mb-12 relative">
           {/* Subtle decorative gradient behind the button that uses theme tokens (no hardcoded colors) */}

--- a/src/app/(landing)/Statistics/Statistics.tsx
+++ b/src/app/(landing)/Statistics/Statistics.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Users, BookOpen, Award, Coins, TrendingUp, Globe } from "lucide-react";
+import StatisticsCard from "@/components/landing/StatisticsCard";
 
 const Statistics: React.FC = () => {
   const stats = [
@@ -80,33 +81,7 @@ const Statistics: React.FC = () => {
         {/* Statistics Grid */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8 mb-16">
           {stats.map((stat, index) => {
-            const IconComponent = stat.icon;
-            return (
-              <div
-                key={index}
-                className="group relative p-8 rounded-2xl backdrop-blur-sm text-center transition-all duration-300 hover:shadow-lg hover:-translate-y-1 hover:bg-background/80"
-              >
-                {/* Icon */}
-                <div className="w-16 h-16 mx-auto mb-6 rounded-2xl bg-primary/10 flex items-center justify-center group-hover:bg-primary/20 transition-colors">
-                  <IconComponent className="w-8 h-8 text-primary" />
-                </div>
-
-                {/* Number */}
-                <h3 className="text-3xl lg:text-4xl font-bold mb-3 text-primary">
-                  {stat.number}
-                </h3>
-
-                {/* Title */}
-                <h4 className="text-lg font-semibold mb-2 text-foreground">
-                  {stat.title}
-                </h4>
-
-                {/* Description */}
-                <p className="text-sm text-muted-foreground leading-relaxed">
-                  {stat.description}
-                </p>
-              </div>
-            );
+            return <StatisticsCard key={index} stat={stat} />;
           })}
         </div>
 

--- a/src/components/landing/StatisticsCard.tsx
+++ b/src/components/landing/StatisticsCard.tsx
@@ -1,39 +1,44 @@
 import React from "react";
-import type { LucideIcon } from "lucide-react";
 
-interface Stat {
-  icon: LucideIcon;
+type IconComponent = React.ComponentType<React.SVGProps<SVGSVGElement>>;
+
+interface StatisticsCardProps {
+  icon: IconComponent;
   number: string;
   title: string;
-  description: string;
+  description?: string;
+  className?: string;
 }
 
-const StatisticsCard: React.FC<{ stat: Stat }> = ({ stat }) => {
-  const IconComponent = stat.icon;
+const StatisticsCard = React.memo(
+  React.forwardRef<HTMLDivElement, StatisticsCardProps>(
+    ({ icon: Icon, number, title, description, className = "" }, ref) => {
+      return (
+        <div
+          ref={ref}
+          className={`group relative p-8 rounded-2xl bg-background/60 backdrop-blur-sm text-center transition-transform duration-300 transform-gpu hover:-translate-y-1 hover:shadow-lg ${className}`}
+        >
+          <div className="w-16 h-16 mx-auto mb-6 rounded-2xl bg-primary/10 flex items-center justify-center transition-colors group-hover:bg-primary/20">
+            <Icon className="w-8 h-8 text-primary" />
+          </div>
 
-  return (
-    <div className="group relative p-8 rounded-2xl backdrop-blur-sm text-center transition-all duration-300 hover:shadow-lg hover:-translate-y-1 hover:bg-background/80">
-      {/* Icon */}
-      <div className="w-16 h-16 mx-auto mb-6 rounded-2xl bg-primary/10 flex items-center justify-center group-hover:bg-primary/20 transition-colors">
-        <IconComponent className="w-8 h-8 text-primary" />
-      </div>
+          <h3 className="text-3xl lg:text-4xl font-extrabold mb-2 text-primary leading-none">
+            {number}
+          </h3>
 
-      {/* Number */}
-      <h3 className="text-3xl lg:text-4xl font-bold mb-3 text-primary">
-        {stat.number}
-      </h3>
+          <h4 className="text-lg font-semibold text-foreground mb-2">{title}</h4>
 
-      {/* Title */}
-      <h4 className="text-lg font-semibold mb-2 text-foreground">
-        {stat.title}
-      </h4>
+          {description && (
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {description}
+            </p>
+          )}
+        </div>
+      );
+    }
+  )
+);
 
-      {/* Description */}
-      <p className="text-sm text-muted-foreground leading-relaxed">
-        {stat.description}
-      </p>
-    </div>
-  );
-};
+StatisticsCard.displayName = "StatisticsCard";
 
 export default StatisticsCard;

--- a/src/components/landing/StatisticsCard.tsx
+++ b/src/components/landing/StatisticsCard.tsx
@@ -1,7 +1,8 @@
 import React from "react";
+import type { LucideIcon } from "lucide-react";
 
 interface Stat {
-  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  icon: LucideIcon;
   number: string;
   title: string;
   description: string;

--- a/src/components/landing/StatisticsCard.tsx
+++ b/src/components/landing/StatisticsCard.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+interface Stat {
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  number: string;
+  title: string;
+  description: string;
+}
+
+const StatisticsCard: React.FC<{ stat: Stat }> = ({ stat }) => {
+  const IconComponent = stat.icon;
+
+  return (
+    <div className="group relative p-8 rounded-2xl backdrop-blur-sm text-center transition-all duration-300 hover:shadow-lg hover:-translate-y-1 hover:bg-background/80">
+      {/* Icon */}
+      <div className="w-16 h-16 mx-auto mb-6 rounded-2xl bg-primary/10 flex items-center justify-center group-hover:bg-primary/20 transition-colors">
+        <IconComponent className="w-8 h-8 text-primary" />
+      </div>
+
+      {/* Number */}
+      <h3 className="text-3xl lg:text-4xl font-bold mb-3 text-primary">
+        {stat.number}
+      </h3>
+
+      {/* Title */}
+      <h4 className="text-lg font-semibold mb-2 text-foreground">
+        {stat.title}
+      </h4>
+
+      {/* Description */}
+      <p className="text-sm text-muted-foreground leading-relaxed">
+        {stat.description}
+      </p>
+    </div>
+  );
+};
+
+export default StatisticsCard;


### PR DESCRIPTION
## PR description
- Summary
  - Trim `Partnership` component to header-only for an incremental PR: includes the "Trusted Ecosystem" badge, the "Powering DeFi Education" title, and the subtitle sentence. A placeholder comment ("the partnership cards will be implemented here") marks where the rest will be added later.
- Files changed
  - Partnership.tsx
  
  
  
  
<img width="1789" height="276" alt="image" src="https://github.com/user-attachments/assets/00d61ef9-e7d7-482a-9bef-49719375b021" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a Partnerships section featuring a “Trusted Ecosystem” badge, headline, and description highlighting DeFi education.
  - Added a Statistics section showcasing platform metrics in a responsive grid with icons, prominent numbers, titles, and optional descriptions.
  - Included a compelling CTA area with a decorative backdrop and “Join the Revolution” button.
  - Enhanced visual polish with gradient-styled headings and glass-effect elements for a modern, engaging landing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->