### PR TITLE
feat: add Partnership component with introductory content for DeFi education

### DIFF
--- a/src/app/(landing)/Partnership/Partnership.tsx
+++ b/src/app/(landing)/Partnership/Partnership.tsx
@@ -1,0 +1,34 @@
+import { Badge } from "@/components/ui/badge";
+
+const Partnership = () => {
+  return (
+    <section className="py-16">
+      <div className="container mx-auto px-4">
+        <div className="text-center">
+          <Badge
+            variant="secondary"
+            className="mb-4 px-4 py-2 text-sm font-medium glass-effect"
+          >
+            Trusted Ecosystem
+          </Badge>
+
+          <h2 className="text-3xl md:text-4xl font-bold mb-2">
+            Powering{" "}
+            <span className="bg-gradient-to-r from-primary via-accent to-primary bg-clip-text text-transparent">
+              DeFi Education
+            </span>
+          </h2>
+
+          <p className="text-base text-muted-foreground max-w-2xl mx-auto leading-relaxed">
+            Learn about the most important protocols and platforms in the DeFi
+            ecosystem through hands-on experience
+          </p>
+
+          {/* partnership card will be implemented here */}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Partnership;


### PR DESCRIPTION

## PR description
Summary
- ✨ Adds the `Partnership` section component and layout used on the landing page.
- 🎯 Highlights a "Trusted Ecosystem" badge and a hero message: "Powering DeFi Education".
- 🧩 Placeholder for partnership cards (to be implemented next).

What I changed
- 🗂️ Added/updated: Partnership.tsx — implements the visual section including `Badge`, heading, and paragraph.

Why
- ✅ Introduces a dedicated Partnership section to showcase ecosystem partners and increase credibility on the landing page.

<img width="1789" height="276" alt="image" src="https://github.com/user-attachments/assets/93aa1f38-6508-40a4-988a-2fe00c00742e" />

